### PR TITLE
lva-wingman-templates to 1.3.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -36,4 +36,4 @@ dependencies:
   version: 1.3.1
 - name: lva-wingman-templates
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.3.5
+  version: 1.3.6


### PR DESCRIPTION
Promote lva-wingman-templates to version 1.3.6