### PR TITLE
lva-electronic-page-handler to 2.3.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -18,7 +18,7 @@ dependencies:
   version: 2.1.4
 - name: lva-electronic-page-handler
   repository: http://jenkins-x-chartmuseum:8080
-  version: 2.3.8
+  version: 2.3.9
 - name: lva-electronic-page-processor
   repository: http://jenkins-x-chartmuseum:8080
   version: 2.2.5


### PR DESCRIPTION
Promote lva-electronic-page-handler to version 2.3.9