### PR TITLE
lva-wingman-templates to 1.3.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -42,7 +42,7 @@ dependencies:
   version: 1.3.3
 - name: lva-wingman-templates
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.3.8
+  version: 1.3.9
 - name: lva-wingman-ui
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.3.8


### PR DESCRIPTION
Promote lva-wingman-templates to version 1.3.9